### PR TITLE
replaced dead link with stable link from internet archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ References
 
 - [Stable Fluids, Jos Stam](http://www.dgp.toronto.edu/people/stam/reality/Research/pdf/ns.pdf)
 - [Real-Time Fluid Dynamics for Games, Jos Stam](https://pdfs.semanticscholar.org/847f/819a4ea14bd789aca8bc88e85e906cfc657c.pdf)
-- [Fast Fluid Dynamics Simulation on the GPU, Mark J. Harris](http://developer.download.nvidia.com/books/HTML/gpugems/gpugems_ch38.html)
+- [Fast Fluid Dynamics Simulation on the GPU, Mark J. Harris](https://web.archive.org/web/20230517074259/https://developer.nvidia.com/gpugems/gpugems/part-vi-beyond-triangles/chapter-38-fast-fluid-dynamics-simulation-gpu)
 
 License
 -------


### PR DESCRIPTION
The old link to GPU Gems "Fast Fluid Dynamics Simulation on the GPU" was giving 404. This PR updates to an internet archive URL so hopefully a more stable URL.