### PR TITLE
Fixed an issue in Canvas.shader preventing startup

### DIFF
--- a/Assets/Marbling/Canvas/Canvas.shader
+++ b/Assets/Marbling/Canvas/Canvas.shader
@@ -8,7 +8,7 @@ Shader "StableFluids/Canvas"
 
 HLSLINCLUDE
 
-#include "../Common/Shaders/CustomRenderTexture.hlsl"
+#include "../../Common/Shaders/CustomRenderTexture.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
 TEXTURE2D(_InjectTex);


### PR DESCRIPTION
Fixed an issue where the Canvas.shader could not find CustomRenderTexture.hlsl due to a bad relative path.